### PR TITLE
Version release artifact names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ All notable changes to Quant are documented here.
 - Added deterministic regime, correlation, source-provenance, and scenario-sensitivity coverage.
 - Verified type checking, Quant tests, production build, and an actual Electron Market Pulse smoke render.
 
+### Packaging
+
+- Versioned release folder and archive names prevent a new build from silently replacing a prior local release.
+
 ## [1.3.1] - 2026-07-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ Download the platform archive from the [GitHub Releases page](https://github.com
 macOS:
 
 ```bash
-open Quant-mac-arm64/Quant.app
+open Quant-v1.4.0-mac-arm64/Quant.app
 ```
 
 Windows PowerShell:
 
 ```powershell
-.\Quant-win-x64\Quant.exe
+.\Quant-v1.4.0-win-x64\Quant.exe
 ```
 
 The source repository contains no packaged binaries. Release ZIPs are published as GitHub Release assets, keeping ordinary clones small and avoiding Git LFS downloads.
@@ -396,11 +396,13 @@ npm run package:all
 Outputs:
 
 ```text
-release/Quant-mac-arm64/Quant.app
-release/Quant-mac-arm64.zip
-release/Quant-win-x64/Quant.exe
-release/Quant-win-x64.zip
+release/Quant-v1.4.0-mac-arm64/Quant.app
+release/Quant-v1.4.0-mac-arm64.zip
+release/Quant-v1.4.0-win-x64/Quant.exe
+release/Quant-v1.4.0-win-x64.zip
 ```
+
+The version is embedded in both the release folder and archive name so a new package never silently replaces the previous release.
 
 Upload the ZIP archives as GitHub Release assets. Do not distribute `Quant.exe` alone because it depends on adjacent Electron runtime files.
 

--- a/scripts/package-release.mjs
+++ b/scripts/package-release.mjs
@@ -1,8 +1,8 @@
 // Creates runnable Electron release folders without requiring electron-builder.
 //
 // Outputs:
-//   release/Quant-mac-<arch>/Quant.app
-//   release/Quant-win-x64/Quant.exe
+//   release/Quant-v<version>-mac-<arch>/Quant.app
+//   release/Quant-v<version>-win-x64/Quant.exe
 //
 // The script builds the app first, then packages the compiled dist/ payload into
 // official Electron runtimes. macOS uses the local Electron runtime when the
@@ -36,6 +36,7 @@ const electronPkg = JSON.parse(readFileSync(r('node_modules/electron/package.jso
 const electronVersion = electronPkg.version;
 const productName = pkg.productName ?? 'Quant';
 const version = pkg.version ?? '0.0.0';
+const releaseName = `${productName}-v${version}`;
 
 const args = new Map(
   process.argv
@@ -201,7 +202,7 @@ async function packageMac(arch) {
   }
 
   const runtimeApp = await resolveMacRuntime(targetArch);
-  const targetDir = r('release', `${productName}-mac-${targetArch}`);
+  const targetDir = r('release', `${releaseName}-mac-${targetArch}`);
   const appPath = path.join(targetDir, `${productName}.app`);
   rmSync(targetDir, { recursive: true, force: true });
   mkdirSync(targetDir, { recursive: true });
@@ -219,12 +220,12 @@ async function packageMac(arch) {
   adHocSignMacApp(appPath);
   copyRuntimeNotice(targetDir);
   log(`macOS app written to ${path.relative(root, appPath)}`);
-  createZipArchive(targetDir, r('release', `${productName}-mac-${targetArch}.zip`));
+  createZipArchive(targetDir, r('release', `${releaseName}-mac-${targetArch}.zip`));
 }
 
 async function packageWindows(arch) {
   const targetArch = arch ?? 'x64';
-  const targetDir = r('release', `${productName}-win-${targetArch}`);
+  const targetDir = r('release', `${releaseName}-win-${targetArch}`);
   const cacheDir = r('.release-cache');
   rmSync(targetDir, { recursive: true, force: true });
   mkdirSync(targetDir, { recursive: true });
@@ -248,7 +249,7 @@ async function packageWindows(arch) {
   makeAppPayload(resourcesDir);
   copyRuntimeNotice(targetDir);
   log(`Windows app written to ${path.relative(root, newExe)}`);
-  createZipArchive(targetDir, r('release', `${productName}-win-${targetArch}.zip`));
+  createZipArchive(targetDir, r('release', `${releaseName}-win-${targetArch}.zip`));
 }
 
 buildApp();


### PR DESCRIPTION
## What changed

- includes the app version in generated release folders and ZIP filenames
- updates README install and packaging paths
- documents the packaging correction in the v1.4.0 changelog

## Why

The fixed artifact names silently replaced prior local packages, making a newly built release appear absent even though its internal app version was current.

## Validation

- npm run typecheck
- npm run test:quant
- npm run package:all
- ZIP integrity checks for both platforms
- macOS deep strict codesign verification
- packaged app manifests report version 1.4.0